### PR TITLE
OM-135: mpay button, bill voucher head panel init

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ __Administration__ ('admin.mainMenu') - it is displayed by default, main entry o
 
 ## Available Contribution Points
 
---- None ---
+* `workerVoucher.VoucherHeadPanel`: Designed to showcase essential information about a voucher's bill, this contribution point facilitates clear and customizable bill displays.
 
 ## Dispatched Redux Actions
 

--- a/src/components/BillVoucherHeadPanel.js
+++ b/src/components/BillVoucherHeadPanel.js
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { Grid, Typography, Divider } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+import {
+  FormattedMessage, PublishedComponent, NumberInput, TextInput,
+} from '@openimis/fe-core';
+import MPayBillButton from './MPayBillButton';
+
+const useStyles = makeStyles((theme) => ({
+  tableTitle: theme.table.title,
+  item: theme.paper.item,
+  fullHeight: {
+    height: '100%',
+  },
+}));
+
+function BillVoucherHeadPanel({ bill }) {
+  const classes = useStyles();
+  return (
+    <>
+      <Grid container direction="row" justifyContent="space-between" alignItems="center" className={classes.tableTitle}>
+        <Grid item>
+          <Grid>
+            <Grid item>
+              <Typography>
+                <FormattedMessage module="invoice" id="bill.headPanelTitle" />
+              </Typography>
+            </Grid>
+          </Grid>
+        </Grid>
+        <MPayBillButton bill={bill} />
+      </Grid>
+      <Divider />
+      <Grid container className={classes.item}>
+        <Grid item xs={3} className={classes.item}>
+          <TextInput module="invoice" label="bill.code" value={bill?.code} readOnly />
+        </Grid>
+        <Grid item xs={3} className={classes.item}>
+          <PublishedComponent
+            pubRef="core.DatePicker"
+            module="invoice"
+            label="bill.dateBill"
+            value={bill?.dateBill}
+            readOnly
+          />
+        </Grid>
+        <Grid item xs={3} className={classes.item}>
+          <PublishedComponent
+            pubRef="core.DatePicker"
+            module="invoice"
+            label="bill.datePayed"
+            value={bill?.datePayed}
+            readOnly
+          />
+        </Grid>
+        <Grid item xs={3} className={classes.item}>
+          <NumberInput module="invoice" label="bill.amountTotal" displayZero value={bill?.amountTotal} readOnly />
+        </Grid>
+        <Grid item xs={3} className={classes.item}>
+          <PublishedComponent
+            pubRef="invoice.InvoiceStatusPicker"
+            label="invoice.status.label"
+            withNull
+            value={bill?.status}
+            readOnly
+          />
+        </Grid>
+        <Grid item xs={3} className={classes.item}>
+          <TextInput module="invoice" label="bill.currencyCode" value={bill?.currencyCode} readOnly />
+        </Grid>
+      </Grid>
+    </>
+  );
+}
+
+export default BillVoucherHeadPanel;

--- a/src/components/MPayBillButton.js
+++ b/src/components/MPayBillButton.js
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import { Grid, Button, Typography } from '@material-ui/core';
+import AccountBalanceIcon from '@material-ui/icons/AccountBalance';
+
+import { useModulesManager, useTranslations, baseApiUrl } from '@openimis/fe-core';
+import {
+  BILL_PAID_STATUS, MODULE_NAME, MPAY_BILL_URL,
+} from '../constants';
+
+function MPayBillButton({ bill }) {
+  const modulesManager = useModulesManager();
+
+  if (!bill || bill.status === BILL_PAID_STATUS) return null;
+
+  const { formatMessage } = useTranslations(MODULE_NAME, modulesManager);
+
+  const handleOnClick = (e) => {
+    e.preventDefault();
+
+    try {
+      const redirectToURL = new URL(`${window.location.origin}${baseApiUrl}${MPAY_BILL_URL}`);
+      redirectToURL.searchParams.set('bill', bill.id);
+
+      window.open(redirectToURL.href, '_blank');
+    } catch (error) {
+      throw new Error('Redirection failed.', error);
+    }
+  };
+
+  return (
+    <Grid item>
+      <Button
+        size="small"
+        variant="contained"
+        color="primary"
+        startIcon={<AccountBalanceIcon />}
+        onClick={handleOnClick}
+      >
+        <Typography variant="subtitle1">{formatMessage('workerVoucher.MPayBillButton')}</Typography>
+      </Button>
+    </Grid>
+  );
+}
+
+export default MPayBillButton;

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,8 @@ export const REF_ROUTE_WORKER_VOUCHER = 'workerVoucher.route.workerVoucher';
 export const REF_ROUTE_WORKER_VOUCHERS = 'workerVoucher.route.workerVouchers';
 export const REF_ROUTE_BILL = 'bill.route.bill';
 
+export const MPAY_BILL_URL = '/msystems/mpay_payment/';
+export const BILL_PAID_STATUS = '2';
 export const DEFAULT_DEBOUNCE_TIME = 800;
 export const DEFAULT_PAGE_SIZE = 10;
 export const VOUCHER_PRICE_DEFAULT_PAGE_SIZE = 5;
@@ -56,4 +58,5 @@ export const WORKER_VOUCHER_STATUS_LIST = [
 
 export const DEFAULT = {
   GENERIC_VOUCHER_ENABLED: false,
+  IS_WORKER: false,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ import WorkerMultiplePicker from './pickers/WorkerMultiplePicker';
 import WorkerDateRangePicker from './pickers/WorkerDateRangePicker';
 import VoucherPriceManagement from './pages/VoucherPriceManagement';
 import MobileAppPasswordManagement from './pages/MobileAppPasswordManagement';
+import BillVoucherHeadPanel from './components/BillVoucherHeadPanel';
 
 const ROUTE_WORKER_VOUCHERS_LIST = 'voucher/vouchers';
 const ROUTE_WORKER_VOUCHER = 'voucher/vouchers/voucher';
@@ -119,6 +120,7 @@ const DEFAULT_CONFIG = {
       filter: (rights) => [INSPECTOR_RIGHT, ADMIN_RIGHT].some((right) => rights.includes(right)),
     },
   ],
+  'workerVoucher.VoucherHeadPanel': [BillVoucherHeadPanel],
 };
 
 export const WorkerVoucherModule = (cfg) => ({ ...DEFAULT_CONFIG, ...cfg });

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -92,5 +92,6 @@
   "workerVoucher.searcher.price": "Price",
   "workerVoucher.filter.date": "Date",
   "business_config.validation.date_range_overlap": "Unable to create the voucher price for the specified period. There is an existing voucher price defined within the selected date range.",
-  "workerVoucher.navigateToTheBill.tooltip": "Bill"
+  "workerVoucher.navigateToTheBill.tooltip": "Bill",
+  "workerVoucher.MPayBillButton": "Pay with MPay"
 }


### PR DESCRIPTION
[OM-135](https://openimis.atlassian.net/browse/OM-135)

Changes:
- Implementation of 'BillVoucherHeadPanel'. It is designed to showcase essential information about voucher's bill (specific to Moldova requirements). It is displayed instead of default BillHeadPanel.
- Implementation of 'MPayBillButton'. It is designed to initialize MPay payment. Available only in BillVoucherHeadPanel and if bill is not paid.
- Lokalise key added.

![image](https://github.com/openimis/openimis-fe-worker_voucher_js/assets/109145288/fd6030d5-1143-462a-a857-9aef3967e033)


[OM-135]: https://openimis.atlassian.net/browse/OM-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ