### PR TITLE
OP-1468: fix error messages shown in failed export dialog

### DIFF
--- a/src/components/VoucherSearcher.js
+++ b/src/components/VoucherSearcher.js
@@ -147,10 +147,10 @@ function VoucherSearcher({ downloadWorkerVoucher, fetchWorkerVouchers, clearWork
       />
       {failedExport && (
         <Dialog open={failedExport} fullWidth maxWidth="sm">
-          <DialogTitle>{errorWorkerVouchers?.message}</DialogTitle>
+          <DialogTitle>{errorWorkerVoucherExport?.message}</DialogTitle>
           <DialogContent>
-            <strong>{`${errorWorkerVouchers?.code}:`}</strong>
-            {errorWorkerVouchers?.detail}
+            <strong>{`${errorWorkerVoucherExport?.code}:`}</strong>
+            {errorWorkerVoucherExport?.detail}
           </DialogContent>
           <DialogActions>
             <Button onClick={handleExportErrorDialogClose} color="primary" variant="contained">

--- a/src/components/VoucherSearcher.js
+++ b/src/components/VoucherSearcher.js
@@ -109,6 +109,8 @@ function VoucherSearcher({ downloadWorkerVoucher, fetchWorkerVouchers, clearWork
       downloadExport(workerVoucherExport, `${formatMessage('export.filename')}.csv`)();
       clearWorkerVoucherExport();
     }
+
+    return setFailedExport(false);
   }, [workerVoucherExport]);
 
   const handleExportErrorDialogClose = () => {


### PR DESCRIPTION
[OP-1468](https://openimis.atlassian.net/browse/OP-1468)

Changes:
- Improve error handling for export failures. Currently, a pop-up message is displayed from the backend.

[OP-1468]: https://openimis.atlassian.net/browse/OP-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ