### PR TITLE
OM-287: block  acquirement and assignment dialog if action is performed

### DIFF
--- a/src/components/VoucherAcquirementGenericVoucher.js
+++ b/src/components/VoucherAcquirementGenericVoucher.js
@@ -36,6 +36,7 @@ function VoucherAcquirementGenericVoucher() {
   const [voucherAcquirement, setVoucherAcquirement] = useState({});
   const [acquirementSummary, setAcquirementSummary] = useState({});
   const [acquirementSummaryLoading, setAcquirementSummaryLoading] = useState(false);
+  const [isPaymentLoading, setIsPaymentLoading] = useState(false);
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const { mutation, submittingMutation } = useSelector((state) => state.workerVoucher);
   const { economicUnit } = useSelector((state) => state.policyHolder);
@@ -60,6 +61,7 @@ function VoucherAcquirementGenericVoucher() {
   };
 
   const onPaymentConfirmation = async () => {
+    setIsPaymentLoading(true);
     try {
       const { payload } = await dispatch(acquireGenericVoucher(
         voucherAcquirement?.employer?.code,
@@ -86,6 +88,8 @@ function VoucherAcquirementGenericVoucher() {
       await payWithMPay(billId);
     } catch (error) {
       throw new Error(`[VOUCHER_ACQUIREMENT_GENERIC_VOUCHER]: Acquirement error. ${error}`);
+    } finally {
+      setIsPaymentLoading(false);
     }
 
     setIsPaymentModalOpen((prevState) => !prevState);
@@ -144,7 +148,7 @@ function VoucherAcquirementGenericVoucher() {
         openState={isPaymentModalOpen}
         onClose={() => setIsPaymentModalOpen((prevState) => !prevState)}
         onConfirm={onPaymentConfirmation}
-        isLoading={acquirementSummaryLoading}
+        isLoading={acquirementSummaryLoading || isPaymentLoading}
         acquirementSummary={acquirementSummary}
         type="acquireUnassignedValidation"
       />

--- a/src/components/VoucherAcquirementPaymentModal.js
+++ b/src/components/VoucherAcquirementPaymentModal.js
@@ -22,7 +22,7 @@ import {
 import { MODULE_NAME } from '../constants';
 
 export const useStyles = makeStyles((theme) => ({
-  primaryButton: theme.dialog.primaryButton,
+  primaryButton: { ...theme.dialog.primaryButton, padding: '6px 12px' },
   secondaryButton: theme.dialog.secondaryButton,
   item: theme.paper.item,
 }));
@@ -43,10 +43,6 @@ function VoucherAcquirementPaymentModal({
   const acquireButtonDisabled = !acceptAcquirement || isLoading || acquirementSummary?.errors;
 
   const renderContent = () => {
-    if (isLoading) {
-      return <CircularProgress />;
-    }
-
     if (acquirementSummary?.errors) {
       return (
         <Typography color="error">
@@ -90,6 +86,7 @@ function VoucherAcquirementPaymentModal({
               color="primary"
               checked={acceptAcquirement}
               onChange={(e) => setAcceptAcquirement(e.target.checked)}
+              disabled={isLoading}
             />
           )}
           label={formatMessage('workerVoucher.acquire.confirmation')}
@@ -99,19 +96,25 @@ function VoucherAcquirementPaymentModal({
   };
 
   return (
-    <Dialog open={openState} onClose={onClose}>
+    <Dialog open={openState} onClose={onClose} disableBackdropClick={isLoading}>
       <DialogTitle>{formatMessage('workerVoucher.VoucherAcquirementPaymentModal.title')}</DialogTitle>
       <Divider />
       <DialogContent>{renderContent()}</DialogContent>
       <Divider style={{ margin: '12px 0' }} />
       <DialogActions>
-        <Button onClick={onClose} className={classes.secondaryButton}>
+        <Button onClick={onClose} className={classes.secondaryButton} disabled={isLoading}>
           {formatMessage('workerVoucher.close')}
         </Button>
         {acquireButtonDisabled ? (
           <Tooltip title={formatMessage('workerVoucher.VoucherAcquirementPaymentModal.confirm.tooltip')}>
             <span>
-              <Button onClick={onConfirm} autoFocus className={classes.primaryButton} disabled={acquireButtonDisabled}>
+              <Button
+                startIcon={isLoading && <CircularProgress size={16} color="secondary" />}
+                onClick={onConfirm}
+                autoFocus
+                className={classes.primaryButton}
+                disabled={acquireButtonDisabled}
+              >
                 {formatMessage('workerVoucher.VoucherAcquirementPaymentModal.confirm')}
               </Button>
             </span>

--- a/src/components/VoucherAcquirementSpecificWorker.js
+++ b/src/components/VoucherAcquirementSpecificWorker.js
@@ -36,6 +36,7 @@ function VoucherAcquirementSpecificWorker() {
   const [voucherAcquirement, setVoucherAcquirement] = useState({});
   const [acquirementSummary, setAcquirementSummary] = useState({});
   const [acquirementSummaryLoading, setAcquirementSummaryLoading] = useState(false);
+  const [isPaymentLoading, setIsPaymentLoading] = useState(false);
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const { mutation, submittingMutation } = useSelector((state) => state.workerVoucher);
   const { economicUnit } = useSelector((state) => state.policyHolder);
@@ -63,6 +64,7 @@ function VoucherAcquirementSpecificWorker() {
   };
 
   const onPaymentConfirmation = async () => {
+    setIsPaymentLoading(true);
     try {
       const { payload } = await dispatch(
         acquireSpecificVoucher(
@@ -93,6 +95,8 @@ function VoucherAcquirementSpecificWorker() {
       await payWithMPay(billId);
     } catch (error) {
       throw new Error(`[VOUCHER_ACQUIREMENT_SPECIFIC_VOUCHER]: Acquirement error. ${error}`);
+    } finally {
+      setIsPaymentLoading(false);
     }
 
     setIsPaymentModalOpen((prevState) => !prevState);
@@ -156,7 +160,7 @@ function VoucherAcquirementSpecificWorker() {
         openState={isPaymentModalOpen}
         onClose={() => setIsPaymentModalOpen((prevState) => !prevState)}
         onConfirm={onPaymentConfirmation}
-        isLoading={acquirementSummaryLoading}
+        isLoading={acquirementSummaryLoading || isPaymentLoading}
         acquirementSummary={acquirementSummary}
         type="acquireAssignedValidation"
       />

--- a/src/components/VoucherAssignmentConfirmModal.js
+++ b/src/components/VoucherAssignmentConfirmModal.js
@@ -22,7 +22,7 @@ import {
 import { MODULE_NAME } from '../constants';
 
 export const useStyles = makeStyles((theme) => ({
-  primaryButton: theme.dialog.primaryButton,
+  primaryButton: { ...theme.dialog.primaryButton, padding: '6px 12px' },
   secondaryButton: theme.dialog.secondaryButton,
   item: theme.paper.item,
 }));
@@ -39,13 +39,9 @@ function VoucherAssignmentConfirmModal({
   const modulesManager = useModulesManager();
   const { formatMessage } = useTranslations(MODULE_NAME, modulesManager);
   const [acceptAssignment, setAcceptAssignment] = useState(false);
-  const acquireButtonDisabled = !acceptAssignment || isLoading || assignmentSummary?.errors;
+  const assignButtonDisabled = !acceptAssignment || isLoading || assignmentSummary?.errors;
 
   const renderContent = () => {
-    if (isLoading) {
-      return <CircularProgress />;
-    }
-
     if (assignmentSummary?.errors) {
       return (
         <Typography color="error">
@@ -89,6 +85,7 @@ function VoucherAssignmentConfirmModal({
               color="primary"
               checked={acceptAssignment}
               onChange={(e) => setAcceptAssignment(e.target.checked)}
+              disabled={isLoading}
             />
           )}
           label={formatMessage('workerVoucher.assign.confirmation')}
@@ -98,25 +95,31 @@ function VoucherAssignmentConfirmModal({
   };
 
   return (
-    <Dialog open={openState} onClose={onClose}>
+    <Dialog open={openState} onClose={onClose} disableBackdropClick={isLoading}>
       <DialogTitle>{formatMessage('workerVoucher.VoucherAssignmentConfirmModal.title')}</DialogTitle>
       <Divider />
       <DialogContent>{renderContent()}</DialogContent>
       <Divider style={{ margin: '12px 0' }} />
       <DialogActions>
-        <Button onClick={onClose} className={classes.secondaryButton}>
+        <Button onClick={onClose} className={classes.secondaryButton} disabled={isLoading}>
           {formatMessage('workerVoucher.close')}
         </Button>
-        {acquireButtonDisabled ? (
+        {assignButtonDisabled ? (
           <Tooltip title={formatMessage('workerVoucher.VoucherAssignmentConfirmModal.confirm.tooltip')}>
             <span>
-              <Button onClick={onConfirm} autoFocus className={classes.primaryButton} disabled={acquireButtonDisabled}>
+              <Button
+                startIcon={isLoading && <CircularProgress size={16} color="secondary" />}
+                onClick={onConfirm}
+                autoFocus
+                className={classes.primaryButton}
+                disabled={assignButtonDisabled}
+              >
                 {formatMessage('workerVoucher.VoucherAssignmentConfirmModal.confirm')}
               </Button>
             </span>
           </Tooltip>
         ) : (
-          <Button onClick={onConfirm} autoFocus className={classes.primaryButton} disabled={acquireButtonDisabled}>
+          <Button onClick={onConfirm} autoFocus className={classes.primaryButton} disabled={assignButtonDisabled}>
             {formatMessage('workerVoucher.VoucherAssignmentConfirmModal.confirm')}
           </Button>
         )}

--- a/src/components/VoucherAssignmentForm.js
+++ b/src/components/VoucherAssignmentForm.js
@@ -36,6 +36,7 @@ function VoucherAssignmentForm() {
   const [voucherAssignment, setVoucherAssignment] = useState({});
   const [assignmentSummary, setAssignmentSummary] = useState({});
   const [assignmentSummaryLoading, setAssignmentSummaryLoading] = useState(false);
+  const [isAssignmentLoading, setIsAssignmentLoading] = useState(false);
   const [isConfirmationModalOpen, setIsConfirmationModalOpen] = useState(false);
   const { mutation, submittingMutation } = useSelector((state) => state.workerVoucher);
   const { economicUnit } = useSelector((state) => state.policyHolder);
@@ -61,6 +62,7 @@ function VoucherAssignmentForm() {
   };
 
   const onAssignmentConfirmation = async () => {
+    setIsAssignmentLoading(true);
     try {
       await dispatch(assignVouchers(
         voucherAssignment?.employer?.code,
@@ -71,6 +73,8 @@ function VoucherAssignmentForm() {
       historyPush(modulesManager, history, REF_ROUTE_WORKER_VOUCHERS);
     } catch (error) {
       throw new Error(`[ASSIGN_VOUCHERS]: Assignment error. ${error}`);
+    } finally {
+      setIsAssignmentLoading(false);
     }
 
     setIsConfirmationModalOpen((prevState) => !prevState);
@@ -136,7 +140,7 @@ function VoucherAssignmentForm() {
             openState={isConfirmationModalOpen}
             onClose={() => setIsConfirmationModalOpen((prevState) => !prevState)}
             onConfirm={onAssignmentConfirmation}
-            isLoading={assignmentSummaryLoading}
+            isLoading={assignmentSummaryLoading || isAssignmentLoading}
             assignmentSummary={assignmentSummary}
           />
         </Paper>


### PR DESCRIPTION
[OM-287](https://openimis.atlassian.net/browse/OM-287)

Changes:
- Add loading spinners and block from closing dialog if acquirement/assignment is being performed.
![Peek 2024-09-05 13-55](https://github.com/user-attachments/assets/728aaa25-baf4-49ec-bb5d-cd041df22c9c)


[OM-287]: https://openimis.atlassian.net/browse/OM-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ